### PR TITLE
Fix check for Pi 5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,4 +18,4 @@ jobs:
       with:
         use-cross: true
         command: build
-        args: --release --target aarch64-unknown-linux-gnu --manifest-path installer/Cargo.toml
+        args: --release --target aarch64-unknown-linux-gnu --manifest-path Cargo.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,12 +694,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lexopt"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baff4b617f7df3d896f97fe922b64817f6cd9a756bb81d40f8883f2f66dcb401"
-
-[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1722,6 +1716,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1985,12 +1985,12 @@ dependencies = [
  "dialoguer",
  "fs_extra",
  "glob",
- "lexopt",
  "log",
  "octocrab",
  "openssl",
  "reqwest",
  "tokio",
+ "urlencoding",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,55 +33,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
-dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
-dependencies = [
- "anstyle",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,52 +142,6 @@ dependencies = [
  "serde",
  "windows-targets 0.52.6",
 ]
-
-[[package]]
-name = "clap"
-version = "4.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c937d4061031a6d0c8da4b9a4f98a172fc2976dfb1c19213a9cf7d0d3c837e36"
-dependencies = [
- "clap_builder",
- "clap_derive",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85379ba512b21a328adf887e85f7742d12e96eb31f3ef077df4ffc26b506ffed"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
-
-[[package]]
-name = "colorchoice"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "console"
@@ -753,12 +658,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,6 +692,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lexopt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baff4b617f7df3d896f97fe922b64817f6cd9a756bb81d40f8883f2f66dcb401"
 
 [[package]]
 name = "libc"
@@ -926,9 +831,9 @@ dependencies = [
 
 [[package]]
 name = "octocrab"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a8a3df00728324ad654ecd1ed449a60157c55b7ff8c109af3a35989687c367"
+checksum = "9305e4c99543ecd0f42bd659c9e9d6ca7115fe5e37d5c85a7277b1db0d4c4101"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1478,12 +1383,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1823,12 +1722,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2088,11 +1981,12 @@ name = "zb-installer"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap",
  "derive_more",
  "dialoguer",
  "fs_extra",
  "glob",
+ "lexopt",
+ "log",
  "octocrab",
  "openssl",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,6 +191,52 @@ dependencies = [
  "serde",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c937d4061031a6d0c8da4b9a4f98a172fc2976dfb1c19213a9cf7d0d3c837e36"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85379ba512b21a328adf887e85f7742d12e96eb31f3ef077df4ffc26b506ffed"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "console"
@@ -656,6 +751,12 @@ dependencies = [
  "memchr",
  "serde",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
@@ -1377,6 +1478,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1716,6 +1823,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1975,6 +2088,7 @@ name = "zb-installer"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "derive_more",
  "dialoguer",
  "fs_extra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,7 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "zb-installer"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [dependencies]
 anyhow = "1.0.86"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ octocrab = "0.39.0"
 reqwest = "0.12.5"
 tokio = { version = "1.38.0", features = ["full"] }
 openssl = { version = "0.10", features = ["vendored"] }
-lexopt = "0.3.0"
 log = "0.4.22"
+urlencoding = "2.1.3"
 
 [profile.release]
 strip = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "zb-installer"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 anyhow = "1.0.86"
-derive_more = "0.99.18"
+derive_more = "1.0.0"
 dialoguer = { version = "0.11.0", features = ["fuzzy-select"] }
 fs_extra = "1.3.0"
 glob = "0.3.1"
-octocrab = "0.38.0"
+octocrab = "0.39.0"
 reqwest = "0.12.5"
 tokio = { version = "1.38.0", features = ["full"] }
 openssl = { version = "0.10", features = ["vendored"] }
@@ -20,8 +20,3 @@ opt-level = "s"
 lto = true
 panic = "abort"
 codegen-units = 1
-
-[features]
-default = ["rpi4", "rpi5"]
-rpi4 = []
-rpi5 = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "zb-installer"
 version = "0.1.0"
@@ -5,7 +7,7 @@ edition = "2024"
 
 [dependencies]
 anyhow = "1.0.86"
-derive_more = "1.0.0"
+derive_more = "0.99.18"
 dialoguer = { version = "0.11.0", features = ["fuzzy-select"] }
 fs_extra = "1.3.0"
 glob = "0.3.1"
@@ -13,6 +15,8 @@ octocrab = "0.39.0"
 reqwest = "0.12.5"
 tokio = { version = "1.38.0", features = ["full"] }
 openssl = { version = "0.10", features = ["vendored"] }
+lexopt = "0.3.0"
+log = "0.4.22"
 
 [profile.release]
 strip = true

--- a/README.md
+++ b/README.md
@@ -5,3 +5,11 @@
 ```
 curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/zymbit-applications/zb-bin/main/install.sh | sh
 ```
+
+### To install non-interactively:
+
+- Download the installer from the "releases" section of this repo or build it yourself
+- Run:
+```
+./zb-install [--with-hardware-signing] [--zb-version latest]
+```

--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/zymbit-ap
 - Download the installer from the "releases" section of this repo or build it yourself
 - Run:
 ```
-./zb-install [--with-hardware-signing] [--zb-version latest]
+./zb-install [--with-hardware-signing | --with-software-signing] [--zb-version <latest|VERSION_TAG>]
 ```

--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-curl -sSL https://github.com/zymbit-applications/zb-bin/releases/download/installer/installer -o /tmp/zb-installer
-
-sudo chmod +x /tmp/zb-installer
-
-sudo /tmp/zb-installer
-
-sudo rm /tmp/zb-installer
+echo "bootstrapping the zbcli installer. you may be asked for your password."
+pushd "$(mktemp -d)" >/dev/null
+curl -sSL https://github.com/zymbit-applications/zb-bin/releases/download/installer/installer -o ./zb-installer
+chmod +x zb-installer
+sudo ./zb-installer
+rm zb-installer
+popd >/dev/null

--- a/src/installer_cli.rs
+++ b/src/installer_cli.rs
@@ -26,8 +26,7 @@ use std::error::Error;
 // You may not use any Zymbit products in life-critical equipment unless authorized officers
 // of the parties have executed a special contract specifically governing such use.
 // -------------------------------------------------------------------------------------------------------
-use anyhow::{bail,Result};
-
+use anyhow::{bail, Result};
 
 #[derive(Debug)]
 pub struct InstallerArgs {
@@ -44,8 +43,10 @@ pub fn parse_args() -> Result<InstallerArgs> {
     while let Some(arg) = argv.next() {
         match arg.as_str() {
             "-h" | "--help" => {
-                println!("usage: zb-install [--with-hardware-signing | --with-software-signing] \
-                                            [--zb-version <latest|VERSION_TAG>]");
+                println!(
+                    "usage: zb-install [--with-hardware-signing | --with-software-signing] \
+                                            [--zb-version <latest|VERSION_TAG>]"
+                );
                 println!("       zb-install [-h | --help]");
                 std::process::exit(0);
             }
@@ -63,12 +64,9 @@ pub fn parse_args() -> Result<InstallerArgs> {
                 bail!("option '--zb-version' requires an argument");
             }
 
-            _ => bail!("unexpected argument {}", arg)
+            _ => bail!("unexpected argument {}", arg),
         }
     }
 
-    Ok(InstallerArgs {
-        use_hw,
-        zb_version,
-    })
+    Ok(InstallerArgs { use_hw, zb_version })
 }

--- a/src/installer_cli.rs
+++ b/src/installer_cli.rs
@@ -1,0 +1,56 @@
+// -------------------------------------------------------------------------------------------------------
+// Copyright (C) 2023, 2024 Zymbit. All rights reserved.
+// Use of this software and associated documentation files (the "Software") is subject to Zymbit
+// terms and conditions, and license, found here:
+//
+// https://www.zymbit.com/terms-and-conditions-of-sale-general/
+// https://www.zymbit.com/software-license-general/
+//
+// Permission to install, use, copy, and modify this software and its documentation for educational,
+// research, and not-for-profit purposes, without fee and without a signed licensing agreement,
+// is hereby granted, provided that the above copyright notice, this paragraph and the following
+// three paragraphs appear in all copies, modifications, and distributions.  Commercial use
+// of any kind requires a written license from Zymbit. Redistribution of this software in original or
+// modified form requires a written license from Zymbit. Refer to full license for details.
+// IN NO EVENT SHALL ZYMBIT INC. OR ITS AGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+// SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+// THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF ZYMBIT HAS BEEN ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+// ZYMBIT SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE AND
+// ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED "AS IS". ZYMBIT HAS
+// NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+//
+// You may not use any Zymbit products in life-critical equipment unless authorized officers
+// of the parties have executed a special contract specifically governing such use.
+// -------------------------------------------------------------------------------------------------------
+pub struct Args {
+    pub use_hw: bool,
+    pub zb_version: Option<String>,
+}
+
+pub fn parse_args() -> Result<Args, lexopt::Error> {
+    use lexopt::prelude::*;
+
+    let mut use_hw = false;
+    let mut zb_version = None;
+    let mut parser = lexopt::Parser::from_env();
+
+    while let Some(arg) = parser.next()? {
+        match arg {
+            Short('h') | Long("help") => {
+                println!("usage: zb-install [--with-hardware-signing] [--zb-version <latest|VERSION>]");
+                println!("       zb-install [-h | --help]");
+                std::process::exit(0);
+            }
+            Long("with-hardware-signing") => use_hw = true,
+            Long("zb-version") => zb_version = Some(parser.value()?.parse()?),
+            _ => return Err(arg.unexpected())
+        }
+    }
+
+    Ok(Args {
+        use_hw,
+        zb_version,
+    })
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,17 +33,17 @@
 
 use std::process;
 
+use crate::system::{OperatingSystem, PiModule};
 use anyhow::{Context, Result};
 use dialoguer::theme::ColorfulTheme;
 use system::ZymbitModule;
 use terminal::{formatted_left_output, OutputColor};
-use crate::system::{OperatingSystem, PiModule};
 
+mod installer_cli;
 mod system;
 mod terminal;
 mod toolchain;
 mod zbcli;
-mod installer_cli;
 
 async fn start() -> Result<()> {
     let cli_args = installer_cli::parse_args()?;
@@ -51,21 +51,21 @@ async fn start() -> Result<()> {
     let system = system::System::get()?;
     println!("{system}");
 
-    let should_use_hardware = system.zymbit_module == ZymbitModule::Scm
-        && match cli_args.use_hw {
-            Some(flag) => flag,
-            None => {
-                dialoguer::Select::with_theme(&ColorfulTheme::default())
+    let should_use_hardware =
+        system.zymbit_module == ZymbitModule::Scm
+            && match cli_args.use_hw {
+                Some(flag) => flag,
+                None => dialoguer::Select::with_theme(&ColorfulTheme::default())
                     .with_prompt(
-                        "'zbcli' comes with software signing by default. Include hardware signing?")
+                        "'zbcli' comes with software signing by default. Include hardware signing?",
+                    )
                     .item("Yes")
                     .item("No")
                     .default(0)
                     .interact()
                     .context("Failed to get signing option")?
-                    == 0
-            }
-    };
+                    == 0,
+            };
 
     let target_asset = match system.pi_module {
         PiModule::Rpi4_64 => {
@@ -84,10 +84,7 @@ async fn start() -> Result<()> {
         }
     };
 
-    toolchain::install::prompt("zbcli",
-                               &target_asset.to_string(),
-                               &cli_args.zb_version,
-    ).await?;
+    toolchain::install::prompt("zbcli", &target_asset.to_string(), &cli_args.zb_version).await?;
 
     println!("Installed zbcli. Run 'zbcli --help' for more options.");
 

--- a/src/system.rs
+++ b/src/system.rs
@@ -176,34 +176,23 @@ pub enum PiModule {
 
 impl PiModule {
     fn get() -> Result<PiModule> {
-        #[cfg(feature = "rpi4")]
+        let model = fs_extra::file::read_to_string(
+            Path::new("/sys/firmware/devicetree/base/model"),
+        )?;
+
+        if model.contains("Raspberry Pi 5")
+            || model.contains("Raspberry Pi Compute Module 5")
         {
-            let model = fs_extra::file::read_to_string(
-                Path::new("/proc").join("device-tree").join("model"),
-            )?;
-
-            if model.contains("Raspberry Pi 5") {
-                bail!("Raspberry Pi 4 version of zb installed, but Raspberry Pi 4 is not detected. Ensure you have the correct zb version installed");
-            }
-
-            // Need explicit return when rpi4 and rpi5 are both set for installer
-            #[allow(clippy::needless_return)]
-            return Ok(PiModule::Rpi4_64);
+           Ok(PiModule::Rpi5_64)
+        } else if model.contains("Raspberry Pi 4")
+            || model.contains("Raspberry Pi Compute Module 4")
+        {
+            Ok(PiModule::Rpi4_64)
+        } else {
+            bail!("Unable to detect Raspberry Pi version. Are you on a Pi/CM4 or Pi/CM5?")
         }
 
-        #[allow(unreachable_code)]
-        #[cfg(feature = "rpi5")]
-        {
-            let model = fs_extra::file::read_to_string(
-                Path::new("/proc").join("device-tree").join("model"),
-            )?;
 
-            if !model.contains("Raspberry Pi 5") {
-                bail!("Raspberry Pi 5 version of zb installed, but Raspberry Pi 5 is not detected. Ensure you have the correct zb version installed");
-            }
-
-            Ok(PiModule::Rpi5_64)
-        }
     }
 }
 

--- a/src/system.rs
+++ b/src/system.rs
@@ -176,14 +176,11 @@ pub enum PiModule {
 
 impl PiModule {
     fn get() -> Result<PiModule> {
-        let model = fs_extra::file::read_to_string(
-            Path::new("/sys/firmware/devicetree/base/model"),
-        )?;
+        let model =
+            fs_extra::file::read_to_string(Path::new("/sys/firmware/devicetree/base/model"))?;
 
-        if model.contains("Raspberry Pi 5")
-            || model.contains("Raspberry Pi Compute Module 5")
-        {
-           Ok(PiModule::Rpi5_64)
+        if model.contains("Raspberry Pi 5") || model.contains("Raspberry Pi Compute Module 5") {
+            Ok(PiModule::Rpi5_64)
         } else if model.contains("Raspberry Pi 4")
             || model.contains("Raspberry Pi Compute Module 4")
         {
@@ -191,8 +188,6 @@ impl PiModule {
         } else {
             bail!("Unable to detect Raspberry Pi version. Are you on a Pi/CM4 or Pi/CM5?")
         }
-
-
     }
 }
 

--- a/src/system.rs
+++ b/src/system.rs
@@ -127,7 +127,7 @@ impl OperatingSystem {
             Ok(OperatingSystem::RpiBullseye)
         } else {
             bail!(
-                "Unsupported distribution. Double check you are running in Ubuntu or Rasberry Pi."
+                "Unsupported distribution. Double check you are running in Ubuntu or Raspberry Pi."
             )
         }
     }
@@ -166,11 +166,11 @@ pub fn add_executable_permission(file: &PathBuf) -> Result<()> {
 #[derive(Display, PartialEq)]
 pub enum PiModule {
     /// Pi 4 or CM 4
-    #[display(fmt = "Rasberry Pi 4")]
+    #[display(fmt = "Raspberry Pi 4")]
     Rpi4_64,
 
     /// Pi 5 or CM 5
-    #[display(fmt = "Rasberry Pi 5")]
+    #[display(fmt = "Raspberry Pi 5")]
     Rpi5_64,
 }
 
@@ -182,8 +182,8 @@ impl PiModule {
                 Path::new("/proc").join("device-tree").join("model"),
             )?;
 
-            if model.contains("Rasberry Pi 5") {
-                bail!("Rasberry Pi 4 version of zb installed, but Rasberry Pi 4 is not detected. Ensure you have the correct zb version installed");
+            if model.contains("Raspberry Pi 5") {
+                bail!("Raspberry Pi 4 version of zb installed, but Raspberry Pi 4 is not detected. Ensure you have the correct zb version installed");
             }
 
             // Need explicit return when rpi4 and rpi5 are both set for installer
@@ -198,8 +198,8 @@ impl PiModule {
                 Path::new("/proc").join("device-tree").join("model"),
             )?;
 
-            if !model.contains("Rasberry Pi 5") {
-                bail!("Rasberry Pi 5 version of zb installed, but Rasberry Pi 5 is not detected. Ensure you have the correct zb version installed");
+            if !model.contains("Raspberry Pi 5") {
+                bail!("Raspberry Pi 5 version of zb installed, but Raspberry Pi 5 is not detected. Ensure you have the correct zb version installed");
             }
 
             Ok(PiModule::Rpi5_64)

--- a/src/system.rs
+++ b/src/system.rs
@@ -117,7 +117,7 @@ pub enum OperatingSystem {
 
 impl OperatingSystem {
     fn get() -> Result<OperatingSystem> {
-        let os_release = fs_extra::file::read_to_string(Path::new("/etc").join("os-release"))?;
+        let os_release = fs_extra::file::read_to_string(Path::new("/etc/os-release"))?;
 
         if is_ubuntu() {
             Ok(OperatingSystem::Ubuntu)
@@ -127,7 +127,7 @@ impl OperatingSystem {
             Ok(OperatingSystem::RpiBullseye)
         } else {
             bail!(
-                "Unsupported distribution. Double check you are running in Ubuntu or Raspberry Pi."
+                "Unsupported distribution. Double check you are running Ubuntu or Raspberry Pi OS/Debian."
             )
         }
     }
@@ -145,7 +145,7 @@ pub enum Kernel {
     Kernel2712img,
 }
 
-/// Equivalent to `chmod +x`
+/// Equivalent to `chmod a+x`
 pub fn add_executable_permission(file: &PathBuf) -> Result<()> {
     let metadata =
         fs::metadata(file).context(format!("Failed to get metadata ({})", file.display()))?;

--- a/src/toolchain/install.rs
+++ b/src/toolchain/install.rs
@@ -14,10 +14,11 @@ use super::version;
 /// Prompts user for version and installs tool to `/usr/bin/{tag_prefix}`
 ///
 /// `tag_prefix`: `zbcli` in `zbcli-1.1.0`
-pub async fn prompt(tag_prefix: &str,
-                    target_asset: &str,
-                    zb_version: &Option<String>) -> Result<()>
-{
+pub async fn prompt(
+    tag_prefix: &str,
+    target_asset: &str,
+    zb_version: &Option<String>,
+) -> Result<()> {
     let releases = version::list(tag_prefix, zb_version).await?;
 
     let releases_list = releases

--- a/src/toolchain/version.rs
+++ b/src/toolchain/version.rs
@@ -2,20 +2,40 @@ use anyhow::{Context, Result};
 use octocrab::models::repos::Release;
 
 /// `tag_prefix`: `zbcli` in `zbcli-1.1.0`
-pub async fn list(tag_prefix: &str) -> Result<Vec<Release>> {
+pub async fn list(tag_prefix: &str, zb_version: &Option<String>)
+    -> Result<Vec<Release>>
+{
     let github_instance = octocrab::instance();
     let repo = github_instance.repos("zymbit-applications", "zb-bin");
 
-    let releases = repo
-        .releases()
-        .list()
-        .per_page(100)
-        .send()
-        .await
-        .context("Failed to get latest release")?;
+    let releases = repo.releases();
 
-    Ok(releases
-        .into_iter()
-        .filter(|release| release.tag_name.starts_with(&format!("{tag_prefix}-")))
-        .collect::<Vec<_>>())
+    let release_list = if let Some(version) = zb_version {
+        let release = if version.to_lowercase().eq("latest") {
+            releases.get_latest()
+                    .await
+                    .context("Failed to get latest release")?
+        } else {
+            eprintln!("Getting specific release tags is not yet supported. "
+                        "Please use the interactive installer.");
+            std::process::exit(1);
+            // TODO: why doesn't this work?
+            // let version_tag = format!("{tag_prefix}-{version}");
+            // releases.get_by_tag(version_tag.as_str())
+            //         .await
+            //         .context(format!("Failed to get release {version}"))?
+        };
+        std::iter::once(release).collect()
+    } else {
+        releases.list()
+                .per_page(10)
+                .send()
+                .await
+                .context("Failed to get latest releases")?
+                .into_iter()
+                .filter(|release| release.tag_name.starts_with(&format!("{tag_prefix}-")))
+                .collect()
+    };
+
+    Ok(release_list)
 }

--- a/src/toolchain/version.rs
+++ b/src/toolchain/version.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use octocrab::models::repos::Release;
+use urlencoding::encode;
 
 /// `tag_prefix`: `zbcli` in `zbcli-1.1.0`
 pub async fn list(tag_prefix: &str, zb_version: &Option<String>)
@@ -16,14 +17,14 @@ pub async fn list(tag_prefix: &str, zb_version: &Option<String>)
                     .await
                     .context("Failed to get latest release")?
         } else {
-            eprintln!("Getting specific release tags is not yet supported. "
-                        "Please use the interactive installer.");
-            std::process::exit(1);
-            // TODO: why doesn't this work?
-            // let version_tag = format!("{tag_prefix}-{version}");
-            // releases.get_by_tag(version_tag.as_str())
-            //         .await
-            //         .context(format!("Failed to get release {version}"))?
+            let version_tag = encode(format!("{tag_prefix}-{version}").as_str()).into_owned();
+            dbg!(&version_tag);
+            releases.get_by_tag(version_tag.as_str())
+                    .await
+                    .context(format!("Failed to get release {version}.\n\
+                    Note that 'zbcli-' should be ommitted from the version argument;\n\
+                    e.g. to select 'zbcli-1.2.0-rc.23', specify '1.2.0-rc.23' as \
+                    the parameter to '--zb-version'"))?
         };
         std::iter::once(release).collect()
     } else {

--- a/src/toolchain/version.rs
+++ b/src/toolchain/version.rs
@@ -3,40 +3,37 @@ use octocrab::models::repos::Release;
 use urlencoding::encode;
 
 /// `tag_prefix`: `zbcli` in `zbcli-1.1.0`
-pub async fn list(tag_prefix: &str, zb_version: &Option<String>)
-    -> Result<Vec<Release>>
-{
+pub async fn list(tag_prefix: &str, zb_version: &Option<String>) -> Result<Vec<Release>> {
     let github_instance = octocrab::instance();
     let repo = github_instance.repos("zymbit-applications", "zb-bin");
 
     let releases = repo.releases();
 
-    let release_list = if let Some(version) = zb_version {
-        let release = if version.to_lowercase().eq("latest") {
-            releases.get_latest()
-                    .await
-                    .context("Failed to get latest release")?
-        } else {
+    // special case when a specific tag is requested
+    if let Some(version) = zb_version {
+        if version.to_lowercase().ne("latest") {
             let version_tag = encode(format!("{tag_prefix}-{version}").as_str()).into_owned();
-            dbg!(&version_tag);
-            releases.get_by_tag(version_tag.as_str())
-                    .await
-                    .context(format!("Failed to get release {version}.\n\
-                    Note that 'zbcli-' should be ommitted from the version argument;\n\
-                    e.g. to select 'zbcli-1.2.0-rc.23', specify '1.2.0-rc.23' as \
-                    the parameter to '--zb-version'"))?
-        };
-        std::iter::once(release).collect()
-    } else {
-        releases.list()
-                .per_page(10)
-                .send()
+            let release = releases
+                .get_by_tag(version_tag.as_str())
                 .await
-                .context("Failed to get latest releases")?
-                .into_iter()
-                .filter(|release| release.tag_name.starts_with(&format!("{tag_prefix}-")))
-                .collect()
-    };
+                .context(format!(
+                    "Failed to get release {version}.\n\
+                    Note that 'zbcli-' should be omitted from the version argument;\n\
+                    e.g. to select 'zbcli-1.2.0-rc.23', specify '1.2.0-rc.23' as \
+                    the parameter to '--zb-version'"
+                ))?;
+            return Ok(std::iter::once(release).collect());
+        }
+    }
 
-    Ok(release_list)
+    let zbcli_filter = releases
+        .list()
+        .per_page(10)
+        .send()
+        .await
+        .context("Failed to get latest releases")?
+        .into_iter()
+        .filter(|release| release.tag_name.starts_with(&format!("{tag_prefix}-")));
+
+    Ok(zbcli_filter.collect())
 }


### PR DESCRIPTION
Fixes the spelling of "Raspberry" when reading from `/proc/device-tree/model` to include a 'p'